### PR TITLE
Following issues resolved on 21May

### DIFF
--- a/app/src/main/res/layout/fragment_body_fat_selection.xml
+++ b/app/src/main/res/layout/fragment_body_fat_selection.xml
@@ -49,7 +49,7 @@
                 android:gravity="center"
                 android:layout_marginTop="16dp"
                 android:fontFamily="@font/dmsans_regular"
-                android:textSize="12sp"/>
+                android:textSize="12sp" />
 
             <RelativeLayout
                 android:layout_width="match_parent"
@@ -81,7 +81,7 @@
                     android:focusable="true"
                     android:imeOptions="actionDone"
                     android:focusableInTouchMode="true"
-                    android:cursorVisible="true"/>
+                    android:cursorVisible="true" />
 
                 <ImageView
                     android:id="@+id/icon_minus"
@@ -102,7 +102,7 @@
                     android:layout_marginEnd="70dp"
                     android:textSize="16sp"
                     android:visibility="gone"
-                    android:layout_centerVertical="true"/>
+                    android:layout_centerVertical="true" />
 
                 <ImageView
                     android:id="@+id/icon_plus"
@@ -115,13 +115,14 @@
                     android:visibility="gone"
                     android:src="@drawable/icon_plus" />
             </RelativeLayout>
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="Or Select From Below"
                 android:textSize="20sp"
                 android:fontFamily="@font/dmsans_bold"
-                android:gravity="center"/>
+                android:gravity="center" />
 
             <RelativeLayout
                 android:layout_width="match_parent"
@@ -134,7 +135,7 @@
                     android:layout_marginTop="16dp"
                     android:layout_marginStart="40dp"
                     android:layout_marginEnd="40dp"
-                    android:layout_above="@id/btn_continue"/>
+                    android:layout_above="@id/btn_continue" />
 
                 <Button
                     android:id="@+id/btn_continue"
@@ -150,7 +151,7 @@
                     android:text="@string/str_continue"
                     android:textColor="@color/white"
                     android:textSize="@dimen/textsize_large"
-                    android:layout_alignParentBottom="true"/>
+                    android:layout_alignParentBottom="true" />
             </RelativeLayout>
 
         </LinearLayout>

--- a/app/src/main/res/layout/grid_item.xml
+++ b/app/src/main/res/layout/grid_item.xml
@@ -10,20 +10,15 @@
     android:background="@color/white"
     android:padding="0dp">
 
-
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_weight="1"
         android:backgroundTint="@color/white"
         android:elevation="5dp"
-        android:gravity="center"
         android:visibility="visible"
         android:orientation="vertical">
 
@@ -31,7 +26,6 @@
             android:id="@+id/item_image"
             android:layout_width="match_parent"
             android:layout_height="120dp"
-            android:layout_weight="1"
             android:scaleType="centerCrop"
             android:src="@drawable/facial_scan" />
 


### PR DESCRIPTION
RAD-2036: At some places content card size is not proper and heading is not properly showing
RAD-2447: Onboarding || Body Fat screen || at first tapping on text area cursor is not appearing user has to tap twice, also user is not able to close keypad
RAD-2719: Explore>RightLife edit section getting crashed
RAD-2736: Face Scan- Height Weight did not populate in Your Details form