### PR TITLE
Following changes done on 4 July 2025

### DIFF
--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/breathwork/BreathworkActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/breathwork/BreathworkActivity.kt
@@ -121,6 +121,6 @@ class BreathworkActivity : BaseActivity() {
 
     private fun callPostMindFullDataAPI() {
         val endDate = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
-        CommonAPICall.postMindFullData(this, "Journaling", startDate, endDate)
+        CommonAPICall.postMindFullData(this, "Breathing", startDate, endDate)
     }
 }

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/breathwork/BreathworkPracticeActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/breathwork/BreathworkPracticeActivity.kt
@@ -273,6 +273,11 @@ class BreathworkPracticeActivity : BaseActivity() {
 
     private fun callPostMindFullDataAPI() {
         val endDate = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
-        CommonAPICall.postMindFullData(this, "Journaling", startDate, endDate)
+        CommonAPICall.postMindFullData(
+            this,
+            breathingData?.title ?: "Breathing",
+            startDate,
+            endDate
+        )
     }
 }

--- a/app/src/main/res/layout/activity_user_interest.xml
+++ b/app/src/main/res/layout/activity_user_interest.xml
@@ -51,7 +51,6 @@
         android:layout_below="@id/ll_interest"
         android:layout_above="@id/ll_bottom"
         android:layout_centerHorizontal="true"
-        android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
         android:fillViewport="true">
         <LinearLayout

--- a/app/src/main/res/layout/activity_wellness_focus_list.xml
+++ b/app/src/main/res/layout/activity_wellness_focus_list.xml
@@ -26,8 +26,8 @@
 
             <ImageView
                 android:id="@+id/img_header"
-                android:layout_width="32dp"
-                android:layout_height="32dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:src="@drawable/header_think_right" />
 
             <TextView
@@ -53,7 +53,7 @@
         android:fontFamily="@font/merriweather_bold"
         android:text="@string/your_journey_your_way"
         android:textColor="@color/txt_color_header"
-        android:textSize="26sp" />
+        android:textSize="20sp" />
 
     <TextView
         android:id="@+id/tv_choose_str"

--- a/app/src/main/res/layout/dialog_welcome.xml
+++ b/app/src/main/res/layout/dialog_welcome.xml
@@ -39,6 +39,6 @@
         android:fontFamily="@font/dmsans_regular"
         android:textSize="20sp"
         android:textColor="@color/txt_color_header"
-        android:text="Join over 40,000 people who are\n living the RightLife."/>
+        android:text="Join over 5000+ people who are\n living the RightLife."/>
 
 </LinearLayout>


### PR DESCRIPTION
- REPLACE ‘40,000’ with ‘5000+’ on the startup splash screen.
- On Wellness Focus List Screen
 1. Resize the MoveRight title icon.
 2. Alter the font size for the hero header section ‘Your journey, your way!’
- User Interest Screen
 1. Increase the spacing between each topics of interest categories.
 2. Use consistent spacing across each category header.
- Allow Personalization Screen all done