### PR TITLE
Following changes done on 4 July 2025

### DIFF
--- a/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HomeDashboardActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HomeDashboardActivity.kt
@@ -508,6 +508,7 @@ class HomeDashboardActivity : BaseActivity(), View.OnClickListener {
         fetchDashboardData()
         getDashboardChecklist("")
         getDashboardChecklistStatus()
+        getAiDashboard("")
     }
 
     private fun loadFragment(fragment: Fragment) {

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/StressManagementSelectionFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/StressManagementSelectionFragment.kt
@@ -290,7 +290,7 @@ class StressManagementSelectionFragment : Fragment() {
                 stressManagementList.add(
                     StressManagement(
                         "Expert",
-                        "I craft my own progressive workouts, track key metrics, and tweak my training as results come in.",
+                        "I craft my own progressive workouts & specialised training programs, and track key metrics.",
                         R.drawable.expert
                     )
                 )

--- a/app/src/main/res/layout/activity_enable_notification.xml
+++ b/app/src/main/res/layout/activity_enable_notification.xml
@@ -145,7 +145,7 @@
                             android:layout_marginTop="8dp"
                             android:layout_marginBottom="8dp"
                             android:fontFamily="@font/dmsans_regular"
-                            android:text="Stay on track with affirmations, workouts, and more."
+                            android:text="Stay on track with affirmations, workouts, workout analysis and more."
                             android:textColor="@color/txt_color_header"
                             android:textSize="18sp" />
 
@@ -223,7 +223,7 @@
                             android:layout_marginTop="8dp"
                             android:layout_marginBottom="8dp"
                             android:fontFamily="@font/dmsans_regular"
-                            android:text="Be the first to know about new features and programs."
+                            android:text="Be the first to know about new features and programs!"
                             android:textColor="@color/txt_color_header"
                             android:textSize="18sp" />
 
@@ -258,7 +258,7 @@
                         android:layout_marginEnd="16dp"
                         android:fontFamily="@font/dmsans_regular"
                         android:gravity="center"
-                        android:text="You are 2.4x more likely to achieve your goals."
+                        android:text="You are 2.4x more likely to achieve your goals!"
                         android:textColor="@color/txt_color_header"
                         android:textSize="12sp" />
 


### PR DESCRIPTION
- On StressManagementSelectionFragment Edit 1 - Modify the 3rd experience level header. New copy - ‘Advanced’. Edit 2 - The subtext below 4th experience level cuts off abruptly.
 New copy - ‘I craft my own progressive workouts & specialised training programs, and track key metrics.’.
- Enable Notification Screen Edit 1 - Update the copy of the subtext in ‘Daily Reminders’. New copy - ‘Stay on track with affirmations, workouts, workout analysis and more.’. Edit 2 - Update the copy of the subtext in ‘Exclusive Updates’. New copy - ‘Be the first to know about new features and programs!’. Edit 2 - Edit the highlight copy. New copy - ‘You are 2.4x more likely to achieve your goals!’.
- HomeDashBoard Refreshes after mindful minutes