### PR TITLE
Disable clicks EatRight, SleepRight, MoveRight and ThinkRight fragments for adapter item 3 seconds on click to improve performance

### DIFF
--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/FoodOptionAdapter.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/FoodOptionAdapter.kt
@@ -4,6 +4,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.databinding.ItemFoodOptionBinding
 import com.jetsynthesys.rightlife.ui.questionnaire.pojo.FoodOption
+import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 
 class FoodOptionAdapter(
     private val options: List<FoodOption>,
@@ -27,6 +28,7 @@ class FoodOptionAdapter(
             }
 
             binding.root.setOnClickListener {
+                binding.root.disableViewForSeconds()
                 val previousPosition = selectedPosition
                 selectedPosition = adapterPosition
                 notifyItemChanged(previousPosition)

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/MealOptionAdapter.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/MealOptionAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.databinding.ItemMealOptionBinding
 import com.jetsynthesys.rightlife.ui.questionnaire.pojo.MealOption
+import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 
 class MealOptionAdapter(
     private val options: List<MealOption>,
@@ -28,6 +29,7 @@ class MealOptionAdapter(
             }
 
             binding.root.setOnClickListener {
+                binding.root.disableViewForSeconds()
                 val prevPos = selectedPosition
                 selectedPosition = adapterPosition
                 notifyItemChanged(prevPos)

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/ScheduleOptionAdapter.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/ScheduleOptionAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.databinding.ItemScheduleOptionBinding
 import com.jetsynthesys.rightlife.ui.questionnaire.pojo.ScheduleOption
+import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 
 class ScheduleOptionAdapter(
     private val options: List<ScheduleOption>,
@@ -40,6 +41,7 @@ class ScheduleOptionAdapter(
             }
 
             binding.root.setOnClickListener {
+                binding.root.disableViewForSeconds()
                 val prevPos = selectedPosition
                 selectedPosition = adapterPosition
                 notifyItemChanged(prevPos)

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/ShakeOffBadDayAdapter.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/ShakeOffBadDayAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.databinding.RowShakeOffBadDayBinding
+import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 
 class ShakeOffBadDayAdapter(
     private val items: List<String>,
@@ -23,6 +24,7 @@ class ShakeOffBadDayAdapter(
                 binding.root.setBackgroundResource(R.drawable.bg_food_item)
             }
             binding.root.setOnClickListener {
+                binding.root.disableViewForSeconds()
                 val previousPosition = selectedPosition
                 selectedPosition = adapterPosition
                 notifyItemChanged(previousPosition)

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/SleepSelectionAdapter.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/SleepSelectionAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.databinding.ItemSleepOptionBinding
 import com.jetsynthesys.rightlife.ui.questionnaire.pojo.SleepOption
+import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 
 class SleepSelectionAdapter(
     private val options: List<SleepOption>,
@@ -30,6 +31,7 @@ class SleepSelectionAdapter(
             }
 
             binding.itemContainer.setOnClickListener {
+                binding.itemContainer.disableViewForSeconds()
                 val previousPosition = selectedPosition
                 selectedPosition = adapterPosition
                 notifyItemChanged(previousPosition)

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/SocialInteractionAdapter.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/adapter/SocialInteractionAdapter.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.databinding.RowSocialInteractionsBinding
 import com.jetsynthesys.rightlife.ui.questionnaire.pojo.SocialInteraction
+import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 
 class SocialInteractionAdapter(
     private val items: List<SocialInteraction>,
@@ -25,6 +26,7 @@ class SocialInteractionAdapter(
                 binding.root.setBackgroundResource(R.drawable.bg_food_item)
             }
             binding.root.setOnClickListener {
+                binding.root.disableViewForSeconds()
                 val previousPosition = selectedPosition
                 selectedPosition = adapterPosition
                 notifyItemChanged(previousPosition)

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/fragment/WaterCaffeineIntakeFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/questionnaire/fragment/WaterCaffeineIntakeFragment.kt
@@ -17,7 +17,6 @@ import com.jetsynthesys.rightlife.ui.questionnaire.pojo.Coffee
 import com.jetsynthesys.rightlife.ui.questionnaire.pojo.ERQuestionFive
 import com.jetsynthesys.rightlife.ui.questionnaire.pojo.Question
 import com.jetsynthesys.rightlife.ui.questionnaire.pojo.Water
-import com.jetsynthesys.rightlife.ui.utility.Utils
 import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 
 class WaterCaffeineIntakeFragment : Fragment() {


### PR DESCRIPTION
- Disable clicks EatRight, SleepRight, MoveRight and ThinkRight fragments for adapter item 3 seconds on click to improve performance