### PR TITLE
Analytics Events added for the following screens

### DIFF
--- a/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HealthCardAdapter.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HealthCardAdapter.kt
@@ -3,7 +3,6 @@ package com.jetsynthesys.rightlife.newdashboard
 import android.content.Intent
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat.startActivity
 import androidx.recyclerview.widget.RecyclerView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.databinding.ItemHealthCardBinding
@@ -11,6 +10,9 @@ import com.jetsynthesys.rightlife.newdashboard.model.DashboardChecklistManager
 import com.jetsynthesys.rightlife.newdashboard.model.DiscoverDataItem
 import com.jetsynthesys.rightlife.ui.healthcam.HealthCamActivity
 import com.jetsynthesys.rightlife.ui.healthcam.NewHealthCamReportActivity
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 
 class HealthCardAdapter(private val cardList: List<DiscoverDataItem>?) :
     RecyclerView.Adapter<HealthCardAdapter.HealthCardViewHolder>() {
@@ -52,6 +54,10 @@ class HealthCardAdapter(private val cardList: List<DiscoverDataItem>?) :
                 } else {
                     Intent(context, HealthCamActivity::class.java)
                 }
+                AnalyticsLogger.logEvent(
+                    context, AnalyticsEvent.DISCOVER_CLICK,
+                    mapOf(AnalyticsParam.DISCOVER_TYPE to item?.parameter!!)
+                )
                 context.startActivity(intent)
             }
         }

--- a/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HeartRateAdapter.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HeartRateAdapter.kt
@@ -18,6 +18,9 @@ import com.jetsynthesys.rightlife.databinding.ItemHeartRateCardBinding
 import com.jetsynthesys.rightlife.newdashboard.model.FacialScan
 import com.jetsynthesys.rightlife.newdashboard.model.ScanData
 import com.jetsynthesys.rightlife.ui.healthcam.ParameterModel
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.DateConverter
 import com.jetsynthesys.rightlife.ui.utility.Utils
 import java.io.Serializable
@@ -108,6 +111,9 @@ class HeartRateAdapter(
                 putExtra("position", holder.bindingAdapterPosition)
             }
             context.startActivity(intent)
+            AnalyticsLogger.logEvent(context, AnalyticsEvent.ALL_HEALTH_DATA_CLICK,
+                mapOf(AnalyticsParam.HEALTH_DATA_TYPE to unifiedList[holder.bindingAdapterPosition])
+            )
         }
     }
 

--- a/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HomeDashboardFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HomeDashboardFragment.kt
@@ -100,6 +100,7 @@ class HomeDashboardFragment : BaseFragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentHomeDashboardBinding.inflate(inflater, container, false)
+        AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.HOME_DASHBOARD_VISIT)
         return binding.root
     }
 
@@ -131,12 +132,14 @@ class HomeDashboardFragment : BaseFragment() {
         }
         binding.includeChecklist.imgQuestionmarkChecklist.setOnClickListener {
             DialogUtils.showCheckListQuestionCommonDialog(requireContext(), "Why Checklist?")
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.WHY_CHECKLIST_CLICK)
             /*startActivity(Intent(this@HomeDashboardActivity, SubscriptionPlanListActivity::class.java).apply {
                 //putExtra("SUBSCRIPTION_TYPE", "SUBSCRIPTION_PLAN")
                 //putExtra("SUBSCRIPTION_TYPE", "FACIAL_SCAN")
             })*/
         }
         binding.includeChecklist.rlChecklistWhyThisDialog.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.FINISH_TO_UNLOCK_CLICK)
             DialogUtils.showCheckListQuestionCommonDialog(requireContext())
         }
 
@@ -168,7 +171,7 @@ class HomeDashboardFragment : BaseFragment() {
             val activity = requireActivity() as HomeNewActivity
             /*val isHealthCamFree = activity.isHealthCamFree*/
 
-            var isHealthCamFree = sharedPreferenceManager?.userProfile?.homeServices
+            var isHealthCamFree = sharedPreferenceManager.userProfile?.homeServices
                 ?.find { it.title == "HealthCam" }
                 ?.isFree ?: false
 
@@ -188,6 +191,7 @@ class HomeDashboardFragment : BaseFragment() {
         }
 
         binding.cardThinkrightMain.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.THINK_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "ThinkRight")
@@ -196,6 +200,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardEatrightMain.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.EAT_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "EatRight")
@@ -205,6 +210,7 @@ class HomeDashboardFragment : BaseFragment() {
         }
 
         binding.cardMoverightMain.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.MOVE_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "MoveRight")
@@ -213,6 +219,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardSleeprightMain.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.SLEEP_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "SleepRight")
@@ -221,6 +228,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardSleepMainIdeal.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.SLEEP_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "SleepRight")
@@ -229,6 +237,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardSleepMainLog.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.SLEEP_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "SleepRight")
@@ -240,6 +249,7 @@ class HomeDashboardFragment : BaseFragment() {
 
         // for no data card
         binding.cardThinkrightMainNodata.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.THINK_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "ThinkRight")
@@ -248,6 +258,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardEatrightMainNodata.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.EAT_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "EatRight")
@@ -258,6 +269,7 @@ class HomeDashboardFragment : BaseFragment() {
 
         binding.cardMoverightMainNodata.setOnClickListener {
             if (checkTrailEndedAndShowDialog()) {
+                AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.MOVE_RIGHT_CLICK)
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "MoveRight")
                     putExtra("BottomSeatName", "Not")
@@ -265,6 +277,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardSleeprightMainNodata.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.SLEEP_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "SleepRight")
@@ -274,6 +287,7 @@ class HomeDashboardFragment : BaseFragment() {
         }
 
         binding.cardEatright.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.EAT_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "EatRight")
@@ -282,6 +296,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardSleepright.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.SLEEP_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "SleepRight")
@@ -290,6 +305,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardThinkright.setOnClickListener {
+            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.THINK_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "ThinkRight")
@@ -299,6 +315,7 @@ class HomeDashboardFragment : BaseFragment() {
         }
         binding.cardMoveright.setOnClickListener {
             if (checkTrailEndedAndShowDialog()) {
+                AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.MOVE_RIGHT_CLICK)
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "MoveRight")
                     putExtra("BottomSeatName", "Not")
@@ -392,6 +409,10 @@ class HomeDashboardFragment : BaseFragment() {
             binding.includeChecklist.imgCheck,
             binding.includeChecklist.rlChecklistProfile
         )
+        AnalyticsLogger.logEvent(
+            requireContext(), AnalyticsEvent.PROFILE_STATUS,
+            mapOf(AnalyticsParam.PROFILE_STATUS to checklistResponse.data.profile)
+        )
         //snap Meal
         setStatusOfChecklist(
             checklistResponse.data.meal_snap,
@@ -399,11 +420,19 @@ class HomeDashboardFragment : BaseFragment() {
             binding.includeChecklist.rlChecklistSnapmeal,
             false
         )
+        AnalyticsLogger.logEvent(
+            requireContext(), AnalyticsEvent.SNAP_MEAL_STATUS,
+            mapOf(AnalyticsEvent.SNAP_MEAL_STATUS to checklistResponse.data.meal_snap)
+        )
         //sync health
         setStatusOfChecklist(
             checklistResponse.data.sync_health_data,
             binding.includeChecklist.imgCheckSynchealth,
             binding.includeChecklist.rlChecklistSynchealth
+        )
+        AnalyticsLogger.logEvent(
+            requireContext(), AnalyticsEvent.SYNC_DATA_STATUS,
+            mapOf(AnalyticsEvent.SYNC_DATA_STATUS to checklistResponse.data.meal_snap)
         )
         // face Scan
         setStatusOfChecklist(
@@ -412,17 +441,29 @@ class HomeDashboardFragment : BaseFragment() {
             binding.includeChecklist.rlChecklistFacescan,
             false
         )
+        AnalyticsLogger.logEvent(
+            requireContext(), AnalyticsEvent.FACIAL_SCAN_STATUS,
+            mapOf(AnalyticsEvent.FACIAL_SCAN_STATUS to checklistResponse.data.vital_facial_scan)
+        )
         // sleep right question
         setStatusOfChecklist(
             checklistResponse.data.unlock_sleep,
             binding.includeChecklist.imgCheckSleepright,
             binding.includeChecklist.rlChecklistSleepright
         )
+        AnalyticsLogger.logEvent(
+            requireContext(), AnalyticsEvent.TR_SR_ASSESSMENT_STATUS,
+            mapOf(AnalyticsEvent.TR_SR_ASSESSMENT_STATUS to checklistResponse.data.meal_snap)
+        )
         // Eat right question
         setStatusOfChecklist(
             checklistResponse.data.discover_eating,
             binding.includeChecklist.imgCheckEatright,
             binding.includeChecklist.rlChecklistEatright
+        )
+        AnalyticsLogger.logEvent(
+            requireContext(), AnalyticsEvent.ER_MR_ASSESSMENT_STATUS,
+            mapOf(AnalyticsEvent.ER_MR_ASSESSMENT_STATUS to checklistResponse.data.meal_snap)
         )
         binding.includeChecklist.tvChecklistNumber.text = "$checkListCount of 6 tasks completed"
         // Chceklist completion logic
@@ -665,7 +706,7 @@ class HomeDashboardFragment : BaseFragment() {
                             module.sleepPerformanceDetail?.actualSleepData?.actualSleepDurationHours?.let {
                                 DateTimeUtils.formatSleepDuration(it)
                             } ?: "0 hr"
-                            )
+                        )
 
 
                         setIfNotNullOrBlank(
@@ -1187,6 +1228,7 @@ class HomeDashboardFragment : BaseFragment() {
             false // Return false if condition is true and dialog is shown
         } else {
             if (!DashboardChecklistManager.checklistStatus) {
+                AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.FINISH_TO_UNLOCK_CLICK)
                 DialogUtils.showCheckListQuestionCommonDialog(requireContext())
                 false
             } else {
@@ -1206,9 +1248,6 @@ class HomeDashboardFragment : BaseFragment() {
 
         bottomSheetDialog.setContentView(bottomSheetView)
 
-
-        bottomSheetDialog.setContentView(bottomSheetView)
-
         // Set up the animation
         val bottomSheetLayout = bottomSheetView.findViewById<LinearLayout>(R.id.design_bottom_sheet)
         if (bottomSheetLayout != null) {
@@ -1223,6 +1262,7 @@ class HomeDashboardFragment : BaseFragment() {
 
         dialogBinding.btnExplorePlan.setOnClickListener {
             bottomSheetDialog.dismiss()
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.SUBSCRIBE_RIGHT_LIFE_CLICK)
             startActivity(Intent(requireContext(), SubscriptionPlanListActivity::class.java).apply {
                 putExtra("SUBSCRIPTION_TYPE", "SUBSCRIPTION_PLAN")
             })

--- a/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HomeDashboardFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HomeDashboardFragment.kt
@@ -191,7 +191,7 @@ class HomeDashboardFragment : BaseFragment() {
         }
 
         binding.cardThinkrightMain.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.THINK_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.THINK_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "ThinkRight")
@@ -200,7 +200,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardEatrightMain.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.EAT_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.EAT_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "EatRight")
@@ -210,7 +210,7 @@ class HomeDashboardFragment : BaseFragment() {
         }
 
         binding.cardMoverightMain.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.MOVE_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.MOVE_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "MoveRight")
@@ -219,7 +219,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardSleeprightMain.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.SLEEP_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.SLEEP_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "SleepRight")
@@ -228,7 +228,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardSleepMainIdeal.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.SLEEP_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.SLEEP_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "SleepRight")
@@ -237,7 +237,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardSleepMainLog.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.SLEEP_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.SLEEP_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "SleepRight")
@@ -249,7 +249,7 @@ class HomeDashboardFragment : BaseFragment() {
 
         // for no data card
         binding.cardThinkrightMainNodata.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.THINK_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.THINK_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "ThinkRight")
@@ -258,7 +258,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardEatrightMainNodata.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.EAT_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.EAT_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "EatRight")
@@ -269,7 +269,7 @@ class HomeDashboardFragment : BaseFragment() {
 
         binding.cardMoverightMainNodata.setOnClickListener {
             if (checkTrailEndedAndShowDialog()) {
-                AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.MOVE_RIGHT_CLICK)
+                AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.MOVE_RIGHT_CLICK)
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "MoveRight")
                     putExtra("BottomSeatName", "Not")
@@ -277,7 +277,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardSleeprightMainNodata.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.SLEEP_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.SLEEP_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "SleepRight")
@@ -287,7 +287,7 @@ class HomeDashboardFragment : BaseFragment() {
         }
 
         binding.cardEatright.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.EAT_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.EAT_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "EatRight")
@@ -296,7 +296,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardSleepright.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.SLEEP_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.SLEEP_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "SleepRight")
@@ -305,7 +305,7 @@ class HomeDashboardFragment : BaseFragment() {
             }
         }
         binding.cardThinkright.setOnClickListener {
-            AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.THINK_RIGHT_CLICK)
+            AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.THINK_RIGHT_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "ThinkRight")
@@ -315,7 +315,7 @@ class HomeDashboardFragment : BaseFragment() {
         }
         binding.cardMoveright.setOnClickListener {
             if (checkTrailEndedAndShowDialog()) {
-                AnalyticsLogger.logEvent(requireContext(),AnalyticsEvent.MOVE_RIGHT_CLICK)
+                AnalyticsLogger.logEvent(requireContext(), AnalyticsEvent.MOVE_RIGHT_CLICK)
                 startActivity(Intent(requireContext(), MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "MoveRight")
                     putExtra("BottomSeatName", "Not")
@@ -649,24 +649,36 @@ class HomeDashboardFragment : BaseFragment() {
                     // MOVE_RIGHT logic here
                     binding.cardMoverightMainNodata.visibility = View.VISIBLE
                     binding.cardMoveright.visibility = View.GONE
+                    binding.cardEatright.visibility = View.VISIBLE
+                    binding.cardThinkright.visibility = View.VISIBLE
+                    binding.cardSleepright.visibility = View.VISIBLE
                 }
 
                 "THINK_RIGHT" -> {
                     // THINK_RIGHT logic here
                     binding.cardThinkrightMainNodata.visibility = View.VISIBLE
                     binding.cardThinkright.visibility = View.GONE
+                    binding.cardMoveright.visibility = View.VISIBLE
+                    binding.cardEatright.visibility = View.VISIBLE
+                    binding.cardSleepright.visibility = View.VISIBLE
                 }
 
                 "EAT_RIGHT" -> {
                     // EAT_RIGHT logic here
                     binding.cardEatrightMainNodata.visibility = View.VISIBLE
                     binding.cardEatright.visibility = View.GONE
+                    binding.cardThinkright.visibility = View.VISIBLE
+                    binding.cardMoveright.visibility = View.VISIBLE
+                    binding.cardSleepright.visibility = View.VISIBLE
                 }
 
                 "SLEEP_RIGHT" -> {
                     // SLEEP_RIGHT logic here
                     binding.cardSleeprightMainNodata.visibility = View.VISIBLE
                     binding.cardSleepright.visibility = View.GONE
+                    binding.cardEatright.visibility = View.VISIBLE
+                    binding.cardThinkright.visibility = View.VISIBLE
+                    binding.cardMoveright.visibility = View.VISIBLE
                 }
 
                 else -> {
@@ -691,6 +703,9 @@ class HomeDashboardFragment : BaseFragment() {
                         if (isSelected == true) {
                             binding.cardMoverightMain.visibility = View.VISIBLE
                             binding.cardMoveright.visibility = View.GONE
+                            binding.cardEatright.visibility = View.VISIBLE
+                            binding.cardThinkright.visibility = View.VISIBLE
+                            binding.cardSleepright.visibility = View.VISIBLE
                         }
                         //set data on card once response works
                         binding.tvCaloryValue.text = module.calorieBalance.toString()
@@ -724,6 +739,9 @@ class HomeDashboardFragment : BaseFragment() {
                         if (isSelected == true) {
                             binding.cardThinkrightMain.visibility = View.VISIBLE
                             binding.cardThinkright.visibility = View.GONE
+                            binding.cardMoveright.visibility = View.VISIBLE
+                            binding.cardEatright.visibility = View.VISIBLE
+                            binding.cardSleepright.visibility = View.VISIBLE
                         }
                         binding.tvMinutesTextValue.text = module.mindfulnessMinutes
                         binding.tvDaysTextValue.text = module.wellnessDays
@@ -751,6 +769,9 @@ class HomeDashboardFragment : BaseFragment() {
                         if (isSelected == true) {
                             binding.cardEatrightMain.visibility = View.VISIBLE
                             binding.cardEatright.visibility = View.GONE
+                            binding.cardThinkright.visibility = View.VISIBLE
+                            binding.cardMoveright.visibility = View.VISIBLE
+                            binding.cardSleepright.visibility = View.VISIBLE
                         }
 
                         val (proteinValue, proteinTotal) = extractNumericValues(module.protein.toString())
@@ -815,6 +836,9 @@ class HomeDashboardFragment : BaseFragment() {
                         if (isSelected == true) {
                             binding.cardSleeprightMain.visibility = View.VISIBLE
                             binding.cardSleepright.visibility = View.GONE
+                            binding.cardEatright.visibility = View.VISIBLE
+                            binding.cardThinkright.visibility = View.VISIBLE
+                            binding.cardMoveright.visibility = View.VISIBLE
                             checkTimeAndSetVisibility(module)
                         }
 

--- a/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HomeNewActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/newdashboard/HomeNewActivity.kt
@@ -60,6 +60,8 @@ import com.jetsynthesys.rightlife.ui.healthcam.HealthCamActivity
 import com.jetsynthesys.rightlife.ui.healthcam.NewHealthCamReportActivity
 import com.jetsynthesys.rightlife.ui.jounal.new_journal.JournalListActivity
 import com.jetsynthesys.rightlife.ui.profile_new.ProfileSettingsActivity
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
 import com.jetsynthesys.rightlife.ui.utility.DateTimeUtils
 import com.jetsynthesys.rightlife.ui.utility.NetworkUtils
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
@@ -203,6 +205,7 @@ class HomeNewActivity : BaseActivity() {
 
         with(binding) {
             includedhomebottomsheet.llJournal.setOnClickListener {
+                AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.EOS_JOURNALING_CLICK)
                 if (checkTrailEndedAndShowDialog()) {
                     startActivity(
                         Intent(
@@ -212,6 +215,7 @@ class HomeNewActivity : BaseActivity() {
                 }
             }
             includedhomebottomsheet.llAffirmations.setOnClickListener {
+                AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.EOS_AFFIRMATION_CLICK)
                 if (checkTrailEndedAndShowDialog()) {
                     startActivity(
                         Intent(
@@ -221,6 +225,7 @@ class HomeNewActivity : BaseActivity() {
                 }
             }
             includedhomebottomsheet.llSleepsounds.setOnClickListener {
+                AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.EOS_SLEEP_SOUNDS)
                 if (checkTrailEndedAndShowDialog()) {
                     startActivity(
                         Intent(
@@ -230,6 +235,7 @@ class HomeNewActivity : BaseActivity() {
                 }
             }
             includedhomebottomsheet.llBreathwork.setOnClickListener {
+                AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.EOS_BREATH_WORK_CLICK)
                 if (checkTrailEndedAndShowDialog()) {
                     startActivity(
                         Intent(
@@ -239,6 +245,7 @@ class HomeNewActivity : BaseActivity() {
                 }
             }
             includedhomebottomsheet.llHealthCamQl.setOnClickListener {
+                AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.EOS_FACE_SCAN_CLICK)
                 if (DashboardChecklistManager.facialScanStatus) {
                     startActivity(
                         Intent(
@@ -250,7 +257,7 @@ class HomeNewActivity : BaseActivity() {
                 }
             }
             includedhomebottomsheet.llMealplan.setOnClickListener {
-
+                AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.EOS_SNAP_MEAL_CLICK)
                 startActivity(Intent(this@HomeNewActivity, MainAIActivity::class.java).apply {
                     putExtra("ModuleName", "EatRight")
                     putExtra("BottomSeatName", "SnapMealTypeEat")
@@ -266,6 +273,7 @@ class HomeNewActivity : BaseActivity() {
         }
 
         binding.includedhomebottomsheet.llFoodLog.setOnClickListener {
+            AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.LYA_FOOD_LOG_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(
                     this@HomeNewActivity, MainAIActivity::class.java
@@ -276,6 +284,7 @@ class HomeNewActivity : BaseActivity() {
             }
         }
         binding.includedhomebottomsheet.llActivityLog.setOnClickListener {
+            AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.LYA_ACTIVITY_LOG_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(
                     this@HomeNewActivity, MainAIActivity::class.java
@@ -291,6 +300,7 @@ class HomeNewActivity : BaseActivity() {
             }
         }
         binding.includedhomebottomsheet.llSleepLog.setOnClickListener {
+            AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.LYA_SLEEP_LOG_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(
                     this@HomeNewActivity, MainAIActivity::class.java
@@ -301,6 +311,7 @@ class HomeNewActivity : BaseActivity() {
             }
         }
         binding.includedhomebottomsheet.llWeightLog.setOnClickListener {
+            AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.LYA_WEIGHT_LOG_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(
                     this@HomeNewActivity, MainAIActivity::class.java
@@ -311,6 +322,7 @@ class HomeNewActivity : BaseActivity() {
             }
         }
         binding.includedhomebottomsheet.llWaterLog.setOnClickListener {
+            AnalyticsLogger.logEvent(this@HomeNewActivity, AnalyticsEvent.LYA_WATER_LOG_CLICK)
             if (checkTrailEndedAndShowDialog()) {
                 startActivity(Intent(
                     this@HomeNewActivity, MainAIActivity::class.java

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/AgeSelectionFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/AgeSelectionFragment.kt
@@ -14,6 +14,9 @@ import android.widget.TextView
 import androidx.cardview.widget.CardView
 import androidx.fragment.app.Fragment
 import com.jetsynthesys.rightlife.R
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 import com.shawnlin.numberpicker.NumberPicker
@@ -163,6 +166,17 @@ class AgeSelectionFragment : Fragment() {
             (activity as OnboardingQuestionnaireActivity).tvSkip.visibility = VISIBLE
         }
 
+        val sharedPreferenceManager = SharedPreferenceManager.getInstance(requireContext())
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.AGE_SELECTION_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
+
         val btnContinue = view.findViewById<Button>(R.id.btn_continue)
         btnContinue.setOnClickListener {
             btnContinue.disableViewForSeconds()
@@ -176,6 +190,18 @@ class AgeSelectionFragment : Fragment() {
             cardViewSelection.visibility = GONE
             llSelectedAge.visibility = VISIBLE
             tvSelectedAge.text = selectedAge
+
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.AGE_SELECTION,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                    AnalyticsParam.GENDER to onboardingQuestionRequest.gender!!,
+                    AnalyticsParam.AGE to selectedAge
+                )
+            )
 
             (activity as OnboardingQuestionnaireActivity).submitAnswer(onboardingQuestionRequest)
         }

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/AwesomeScreenActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/AwesomeScreenActivity.kt
@@ -6,12 +6,25 @@ import android.os.Handler
 import android.os.Looper
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.BaseActivity
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 
 class AwesomeScreenActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setChildContentView(R.layout.activity_awesome_screen)
+
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.AWESOME_SCREEN_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+            )
+        )
 
         Handler(Looper.getMainLooper()).postDelayed({
             startActivity(Intent(this, EnableNotificationActivity::class.java))

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/BodyFatSelectionFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/BodyFatSelectionFragment.kt
@@ -16,6 +16,9 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.databinding.FragmentBodyFatSelectionBinding
 import com.jetsynthesys.rightlife.ui.new_design.pojo.BodyFat
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.DecimalDigitsInputFilter
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
@@ -61,6 +64,17 @@ class BodyFatSelectionFragment : Fragment() {
         if (!(activity as OnboardingQuestionnaireActivity).forProfileChecklist) {
             (activity as OnboardingQuestionnaireActivity).tvSkip.visibility = VISIBLE
         }
+
+        val sharedPreferenceManager = SharedPreferenceManager.getInstance(requireContext())
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.BODY_FAT_SELECTION_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
 
         binding.edtBodyFat.filters = arrayOf(DecimalDigitsInputFilter())
 
@@ -129,6 +143,21 @@ class BodyFatSelectionFragment : Fragment() {
                 onboardingQuestionRequest.bodyFat = binding.edtBodyFat.text.toString()
                 SharedPreferenceManager.getInstance(requireContext())
                     .saveOnboardingQuestionAnswer(onboardingQuestionRequest)
+
+                AnalyticsLogger.logEvent(
+                    AnalyticsEvent.BODY_FAT_SELECTION,
+                    mapOf(
+                        AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                        AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                        AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                        AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                        AnalyticsParam.GENDER to onboardingQuestionRequest.gender!!,
+                        AnalyticsParam.AGE to onboardingQuestionRequest.age!!,
+                        AnalyticsParam.HEIGHT to onboardingQuestionRequest.height!!,
+                        AnalyticsParam.WEIGHT to onboardingQuestionRequest.weight!!,
+                        AnalyticsParam.BODY_FAT to binding.tvSelectedBodyFat.text
+                    )
+                )
 
                 (activity as OnboardingQuestionnaireActivity).submitAnswer(onboardingQuestionRequest)
             } else

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/CreateUsernameActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/CreateUsernameActivity.kt
@@ -16,6 +16,9 @@ import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.BaseActivity
 import com.jetsynthesys.rightlife.apimodel.userdata.Userdata
 import com.jetsynthesys.rightlife.ui.CommonAPICall
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.AppConstants
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.Utils
@@ -34,6 +37,10 @@ class CreateUsernameActivity : BaseActivity() {
         var username = intent.getStringExtra("USERNAME_KEY")
         var email = intent.getStringExtra("EMAIL")
 
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.CREATE_USER_SCREEN_VISIT,
+            mapOf(AnalyticsParam.TIMESTAMP to System.currentTimeMillis())
+        )
 
         val edtUsername = findViewById<EditText>(R.id.edt_username)
         val sharedPreferenceManager = SharedPreferenceManager.getInstance(this)

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/DataControlActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/DataControlActivity.kt
@@ -13,10 +13,13 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.TextView
 import androidx.core.content.ContextCompat
-import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.BaseActivity
+import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.ui.drawermenu.PrivacyPolicyActivity
 import com.jetsynthesys.rightlife.ui.drawermenu.TermsAndConditionsActivity
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 
 class DataControlActivity : BaseActivity() {
     private val agreeString =
@@ -36,8 +39,13 @@ class DataControlActivity : BaseActivity() {
         val chkPrivacyPolicy: CheckBox = findViewById(R.id.ck_privacy_policy)
         val chkTermsAndConditions: CheckBox = findViewById(R.id.ck_terms_conditions)
 
-         tvPrivacyPolicy = findViewById(R.id.tv_privacy_policy)
-         tvTermsAndConditions = findViewById(R.id.tv_terms_condition)
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.DATA_CONTROL_SCREEN_VISIT,
+            mapOf(AnalyticsParam.TIMESTAMP to System.currentTimeMillis())
+        )
+
+        tvPrivacyPolicy = findViewById(R.id.tv_privacy_policy)
+        tvTermsAndConditions = findViewById(R.id.tv_terms_condition)
 
         val btnContinue = findViewById<Button>(R.id.btn_continue)
 
@@ -50,7 +58,7 @@ class DataControlActivity : BaseActivity() {
         val colorStateListDisabled = ContextCompat.getColorStateList(this, R.color.rightlife)
 
 
-        tvPrivacyPolicy.setOnClickListener{
+        tvPrivacyPolicy.setOnClickListener {
             //startActivity(Intent(this, PrivacyPolicyActivity::class.java))
 
         }
@@ -75,7 +83,7 @@ class DataControlActivity : BaseActivity() {
         }
 
         // -------- second checkbox text
-       TncClickMethod()
+        TncClickMethod()
         // First checkbox text
         IagreeClickMethod()
     }
@@ -114,6 +122,7 @@ class DataControlActivity : BaseActivity() {
                             )
                             startActivity(intent)
                         }
+
                         "https://example.com/terms" -> {
                             // Handle Terms and Conditions click
                             //Toast.makeText(this@DataControlActivity,"Terms Policy",Toast.LENGTH_SHORT).show()
@@ -171,9 +180,10 @@ class DataControlActivity : BaseActivity() {
                             )
                             startActivity(intent)
                         }
+
                         "https://example.com/terms" -> {
                             // Handle Terms and Conditions click
-                           // Toast.makeText(this@DataControlActivity,"Terms Policy",Toast.LENGTH_SHORT).show()
+                            // Toast.makeText(this@DataControlActivity,"Terms Policy",Toast.LENGTH_SHORT).show()
                             val intent = Intent(
                                 this@DataControlActivity,
                                 TermsAndConditionsActivity::class.java

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/EnableNotificationActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/EnableNotificationActivity.kt
@@ -13,6 +13,9 @@ import androidx.core.content.ContextCompat
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.BaseActivity
 import com.jetsynthesys.rightlife.ui.CommonAPICall
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 
 class EnableNotificationActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -23,10 +26,28 @@ class EnableNotificationActivity : BaseActivity() {
         findViewById<ImageView>(R.id.imageClose).setOnClickListener {
             sharedPreferenceManager.enableNotification = true
             startActivity(Intent(this, SyncNowActivity::class.java))
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.ENABLE_NOTIFICATION_CLOSE,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                )
+            )
         }
 
         btnEnableNotification.setOnClickListener {
             checkPermission()
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.ENABLE_NOTIFICATION_CLICK,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                )
+            )
         }
     }
 

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/FreeTrialServiceActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/FreeTrialServiceActivity.kt
@@ -11,6 +11,9 @@ import com.jetsynthesys.rightlife.BaseActivity
 import com.jetsynthesys.rightlife.databinding.ActivityFreeTrialBinding
 import com.jetsynthesys.rightlife.ui.CommonResponse
 import com.jetsynthesys.rightlife.ui.settings.GeneralInformationActivity
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.Utils
 import retrofit2.Call
 import retrofit2.Callback
@@ -24,6 +27,16 @@ class FreeTrialServiceActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityFreeTrialBinding.inflate(layoutInflater)
         setChildContentView(binding.root)
+
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.BEGIN_FREE_TRIAL_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+            )
+        )
 
         val combinedHtmlText =
             "<p><b>Premium Features</b></p>" + "<p><b><img src='heart_icon' width='20' height='20' align='texttop'/> MyHealth</b></p>" + "<p><b>Face Scan:</b></p>" + "<p>Measure vitals like BP, stress, and heart health in seconds.</p>" + "<p>Wearable Sync & Analysis</p>" + "<p>Consolidate and analyse all your wearable data in one place.</p>" + "<p><b><img src='thinkright_icon' width='20' height='20' align='texttop'/> ThinkRight:</b></p>" + "<p>Mindfulness Minutes</p>" + "<p>Log your meditation and relaxation time for better mental well-being.</p>" + "<p>Mood Tracker</p>" + "<p>Record daily moods and recognise emotional trends.</p>" + "<p>Guided Journaling</p>" + "<p>Reflect and express with structured journaling options.</p>" + "<p>Affirmations</p>" + "<p>Boost motivation with daily positive affirmations.</p>" + "<p>Breathing Techniques</p>" + "<p>Practice four guided breathing exercises for stress relief.</p>" + "<p>Inspirational Quotes</p>" + "<p>Receive daily doses of motivation and wisdom.</p>" + "<p>Mind Audits</p>" + "<p>Assess mental well-being with standardised evaluations for stress, depression, and more.</p>" + "<p><b><img src='moveright_icon' width='20' height='20' align='texttop'/> MoveRight:</b></p>" + "<p>Calorie Analysis</p>" + "<p>Understand whether you're burning or consuming more calories daily.</p>" + "<p>Workout HR Analysis</p>" + "<p>Track heart rate performance during workouts for better training.</p>" + "<p>Step Tracker</p>" + "<p>Keep an eye on your daily step count to maintain activity levels.</p>" + "<p>Vitals Monitoring</p>" + "<p>Access key health metrics like HRV, RHR, Active Burn, and Average HR.</p>" + "<p><b><img src='eatright_icon' width='20' height='20' align='texttop'/> EatRight:</b></p>" + "<p>Daily Macro & Micro Nutrient Analysis</p>" + "<p>Get a complete breakdown of your daily intake to ensure balanced nutrition.</p>" + "<p>Personalised Meal Plans</p>" + "<p>Enjoy customised meal plans tailored to your goals and preferences.</p>" + "<p>Recipes</p>" + "<p>Explore thousands of healthy, goal-aligned recipes.</p>" + "<p>Snap-to-Log Calories</p>" + "<p>Instantly log meals by snapping a photo—fast, easy, and accurate.</p>" + "<p>Meal Logging</p>" + "<p>Track your food intake effortlessly to stay on top of your nutrition.</p>" + "<p>Meal Insights</p>" + "<p>Compare logged meals with your nutritional targets for better choices.</p>" + "<p>Hydration Tracker</p>" + "<p>Stay hydrated with daily water intake tracking.</p>" + "<p>Weight Tracker</p>" + "<p>Monitor weight trends and progress over time.</p>" + "<p><b><img src='sleepright_icon' width='20' height='20' align='texttop'/> SleepRight:</b></p>" + "<p>Sleep Music, Stories & Sounds</p>" + "<p>Relax and drift off with soothing audio aids.</p>" + "<p>Daily Ideal Sleep Needed</p>" + "<p>Get dynamic sleep duration recommendations based on daily activity.</p>" + "<p>Sleep Consistency Tracking</p>" + "<p>Monitor bedtime regularity and improve sleep patterns.</p>" + "<p>Sleep Stage Analysis</p>" + "<p>Understand your sleep cycles, from deep to REM sleep.</p>" + "<p><b>FAQs</b></p>" + "<p><b>1. What features do I get access to during my free trial?</b></p>" + "<p>You get full access to all our Premium Features listed above, including MyHealth, ThinkRight, MoveRight, EatRight, and SleepRight, for 7 days.</p>" + "<p><b>2. Do I need to add payment details to start my free trial?</b></p>" + "<p>No, you can start your 7-day free trial without entering any payment details.</p>" + "<p><b>3. Will I be charged automatically after the free trial ends?</b></p>" + "<p>No, you will not be charged automatically. You can choose to subscribe to a monthly or annual plan to continue enjoying premium features after the free trial period.</p>" + "<p><b>4. How do I track my free trial period and know when it ends?</b></p>" + "<p>A countdown bar at the top of the app keeps you updated on your trial period. You'll also receive notifications and alerts to remind you.</p>" + "<p><b>5. Can I cancel my free trial anytime?</b></p>" + "<p>Our trial is completely free, without any need to enter card details, so we recommend exploring all premium features first and then make a decision with no strings attached.</p>" + "<p><b>6. What happens to my data after the trial ends?</b></p>" + "<p>Your data remains safe and secure under GDPR & HIPAA compliance. You'll still be able to view past analytics, trends, and scores within the app that you access during your trial period.</p>" + "<p><b>7. If I don't subscribe after the trial, can I still use RightLife?</b></p>" + "<p>Yes, you will still have access to app content under the Explore tab, but Premium Features will be locked. To continue your health journey and make the best of RightLife, we recommend subscribing.</p>" + "<p><b>8. Can I extend my free trial period?</b></p>" + "<p>No, the maximum free trial period is 7 days at this time.</p>".trimIndent()
@@ -45,6 +58,15 @@ class FreeTrialServiceActivity : BaseActivity() {
 
         binding.btnBeginFreeTrial.setOnClickListener {
             beginFreeTrial()
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.BEGIN_FREE_TRIAL_CLICK,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                )
+            )
         }
 
     }

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/GenderSelectionFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/GenderSelectionFragment.kt
@@ -17,6 +17,9 @@ import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.Fragment
 import com.jetsynthesys.rightlife.R
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 
@@ -58,6 +61,17 @@ class GenderSelectionFragment : Fragment() {
         tvDescription = view.findViewById(R.id.tv_description)
 
         handler = Handler(Looper.getMainLooper())
+
+        val sharedPreferenceManager = SharedPreferenceManager.getInstance(requireContext())
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.GENDER_SELECTION_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
 
         val bgDrawable = AppCompatResources.getDrawable(requireContext(), R.drawable.bg_gray_border)
 
@@ -150,6 +164,17 @@ class GenderSelectionFragment : Fragment() {
         SharedPreferenceManager.getInstance(requireContext())
             .saveOnboardingQuestionAnswer(onboardingQuestionRequest)
         (activity as OnboardingQuestionnaireActivity).submitAnswer(onboardingQuestionRequest)
+        val sharedPreferenceManager = SharedPreferenceManager.getInstance(requireContext())
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.GENDER_SELECTION,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                AnalyticsParam.GENDER to selectedGender
+            )
+        )
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/HealthGoalFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/HealthGoalFragment.kt
@@ -18,6 +18,9 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.ui.new_design.pojo.HealthGoal
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 
@@ -59,6 +62,17 @@ class HealthGoalFragment : Fragment() {
         if (!(activity as OnboardingQuestionnaireActivity).forProfileChecklist) {
             (activity as OnboardingQuestionnaireActivity).tvSkip.visibility = VISIBLE
         }
+
+        val sharedPreferenceManager = SharedPreferenceManager.getInstance(requireContext())
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.ACHIEVE_HEALTH_GOALS_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
 
         healthGoalList.add(HealthGoal("0-10 minutes"))
         healthGoalList.add(HealthGoal("10-20 minutes"))
@@ -104,6 +118,22 @@ class HealthGoalFragment : Fragment() {
             onboardingQuestionRequest.dailyGoalAchieveTime = selectedHealthGoal
             SharedPreferenceManager.getInstance(requireContext())
                 .saveOnboardingQuestionAnswer(onboardingQuestionRequest)
+
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.ACHIEVE_HEALTH_GOALS_SELECTION,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                    AnalyticsParam.GENDER to onboardingQuestionRequest.gender!!,
+                    AnalyticsParam.AGE to onboardingQuestionRequest.age!!,
+                    AnalyticsParam.HEIGHT to onboardingQuestionRequest.height!!,
+                    AnalyticsParam.WEIGHT to onboardingQuestionRequest.weight!!,
+                    AnalyticsParam.BODY_FAT to onboardingQuestionRequest.bodyFat!!,
+                    AnalyticsParam.STRESS_MANAGEMENT to selectedHealthGoal
+                )
+            )
 
             (activity as OnboardingQuestionnaireActivity).submitAnswer(onboardingQuestionRequest)
         }

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/HeightSelectionFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/HeightSelectionFragment.kt
@@ -21,6 +21,9 @@ import androidx.recyclerview.widget.LinearSnapHelper
 import androidx.recyclerview.widget.RecyclerView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.ui.CommonAPICall
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
 import java.text.DecimalFormat
@@ -86,6 +89,17 @@ class HeightSelectionFragment : Fragment() {
         if (!(activity as OnboardingQuestionnaireActivity).forProfileChecklist) {
             (activity as OnboardingQuestionnaireActivity).tvSkip.visibility = VISIBLE
         }
+
+        val sharedPreferenceManager = SharedPreferenceManager.getInstance(requireContext())
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.HEIGHT_SELECTION_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
 
         rulerView = view.findViewById(R.id.rulerView)
         val markerView = view.findViewById<View>(R.id.markerView)
@@ -176,6 +190,19 @@ class HeightSelectionFragment : Fragment() {
                 cardViewSelection.visibility = GONE
                 llSelectedHeight.visibility = VISIBLE
                 tvSelectedHeight.text = selectedHeight
+
+                AnalyticsLogger.logEvent(
+                    AnalyticsEvent.HEIGHT_SELECTION,
+                    mapOf(
+                        AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                        AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                        AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                        AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                        AnalyticsParam.GENDER to onboardingQuestionRequest.gender!!,
+                        AnalyticsParam.AGE to onboardingQuestionRequest.age!!,
+                        AnalyticsParam.HEIGHT to selectedHeight
+                    )
+                )
 
                 (activity as OnboardingQuestionnaireActivity).submitAnswer(onboardingQuestionRequest)
             }

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/ImageSliderActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/ImageSliderActivity.kt
@@ -103,6 +103,11 @@ class ImageSliderActivity : BaseActivity() {
 
         viewPager.adapter = ImageSliderAdapter(this, images, headers, descriptions)
 
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.LOGIN_SCREEN_VISIT,
+            mapOf(AnalyticsParam.TIMESTAMP to System.currentTimeMillis())
+        )
+
         // Set up the TabLayoutMediator to sync dots with the images
         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
             // You can set custom content for tabs if needed, but we are using default dots
@@ -195,6 +200,11 @@ class ImageSliderActivity : BaseActivity() {
         btnGoogle.setOnClickListener {
 //            startActivity(Intent(this, CreateUsernameActivity::class.java))
 //            finish()
+
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.CONTINUE_WITH_GOOGLE_CLICK,
+                mapOf(AnalyticsParam.TIMESTAMP to System.currentTimeMillis())
+            )
 
             val signInIntent = googleSignInClient.signInIntent
             startActivityForResult(signInIntent, RC_SIGN_IN)

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/OnboardingFinalActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/OnboardingFinalActivity.kt
@@ -10,6 +10,9 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.BaseActivity
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 
 class OnboardingFinalActivity : BaseActivity() {
 
@@ -37,6 +40,16 @@ class OnboardingFinalActivity : BaseActivity() {
         llOnboardingFinal2 = findViewById(R.id.ll_final_onboarding2)
         llOnboardingFinal3 = findViewById(R.id.ll_final_onboarding3)
         llOnboardingFinal4 = findViewById(R.id.ll_final_onboarding4)
+
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.CRAFTING_PERSONALISE_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+            )
+        )
 
         val handler = Handler(Looper.getMainLooper())
         handler.postDelayed({

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/OnboardingQuestionnaireActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/OnboardingQuestionnaireActivity.kt
@@ -65,6 +65,28 @@ class OnboardingQuestionnaireActivity : BaseActivity() {
         tv_fragment_count = findViewById(R.id.tv_fragment_count)
         tvSkip = findViewById(R.id.tv_skip)
         tvSkip.setOnClickListener {
+            val eventName =
+                when (viewPager.currentItem) {
+                    0 -> AnalyticsEvent.GENDER_SELECTION_SKIP_CLICK
+                    1 -> AnalyticsEvent.AGE_SELECTION_SKIP
+                    2 -> AnalyticsEvent.HEIGHT_SELECTION_SKIP
+                    3 -> AnalyticsEvent.WEIGHT_SELECTION_SKIP
+                    4 -> AnalyticsEvent.BODY_FAT_SELECTION_SKIP
+                    5 -> AnalyticsEvent.STRESS_MANAGEMENT_SKIP
+                    6 -> AnalyticsEvent.ACHIEVE_HEALTH_GOALS_SKIP
+                    else -> {
+                        ""
+                    }
+                }
+            AnalyticsLogger.logEvent(
+                eventName,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+                )
+            )
             if (viewPager.currentItem == 0) {
                 adapter.removeItem("BodyFatSelection")
             }

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/PersonalisationActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/PersonalisationActivity.kt
@@ -6,6 +6,9 @@ import android.widget.Button
 import android.widget.TextView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.BaseActivity
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 
 class PersonalisationActivity : BaseActivity() {
@@ -20,6 +23,16 @@ class PersonalisationActivity : BaseActivity() {
             header = sharedPreferenceManager.selectedWellnessFocus
         }
 
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.ALLOW_PERSONALISATION_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
+
         val tvSkip = findViewById<TextView>(R.id.tv_skip)
         tvSkip.setOnClickListener {
             sharedPreferenceManager.allowPersonalization = true
@@ -27,6 +40,15 @@ class PersonalisationActivity : BaseActivity() {
             val intent = Intent(this, EnableNotificationActivity::class.java)
             intent.putExtra("WellnessFocus", header)
             startActivity(intent)
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.ALLOW_PERSONALISATION_SKIP_CLICK,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+                )
+            )
         }
 
         val btnAllowPersonalisation = findViewById<Button>(R.id.btn_allow_personalisation)
@@ -35,6 +57,15 @@ class PersonalisationActivity : BaseActivity() {
             intent.putExtra("WellnessFocus", header)
             sharedPreferenceManager.allowPersonalization = true
             startActivity(intent)
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.ALLOW_PERSONALISATION_CLICK,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+                )
+            )
         }
     }
 }

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/StressManagementSelectionFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/StressManagementSelectionFragment.kt
@@ -19,6 +19,9 @@ import com.jetsynthesys.rightlife.RetrofitData.ApiClient
 import com.jetsynthesys.rightlife.RetrofitData.ApiService
 import com.jetsynthesys.rightlife.ui.new_design.pojo.OnBoardingModuleResponse
 import com.jetsynthesys.rightlife.ui.new_design.pojo.StressManagement
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.AppConstants
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
@@ -69,6 +72,17 @@ class StressManagementSelectionFragment : Fragment() {
             (activity as OnboardingQuestionnaireActivity).tvSkip.visibility = VISIBLE
         }
 
+        val sharedPreferenceManager = SharedPreferenceManager.getInstance(requireContext())
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.STRESS_MANAGEMENT_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
+
         val btnContinue = view.findViewById<Button>(R.id.btn_continue)
 
         header = arguments?.getString("HEADER").toString()
@@ -109,6 +123,23 @@ class StressManagementSelectionFragment : Fragment() {
                 selectedStressManagement.header
             SharedPreferenceManager.getInstance(requireContext())
                 .saveOnboardingQuestionAnswer(onboardingQuestionRequest)
+
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.STRESS_MANAGEMENT_SELECTION,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                    AnalyticsParam.GENDER to onboardingQuestionRequest.gender!!,
+                    AnalyticsParam.AGE to onboardingQuestionRequest.age!!,
+                    AnalyticsParam.HEIGHT to onboardingQuestionRequest.height!!,
+                    AnalyticsParam.WEIGHT to onboardingQuestionRequest.weight!!,
+                    AnalyticsParam.BODY_FAT to onboardingQuestionRequest.bodyFat!!,
+                    AnalyticsParam.STRESS_MANAGEMENT to selectedStressManagement.header
+                )
+            )
+
             (activity as OnboardingQuestionnaireActivity).submitAnswer(onboardingQuestionRequest)
         }
 

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/SyncNowActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/SyncNowActivity.kt
@@ -35,6 +35,7 @@ import com.jetsynthesys.rightlife.ui.CommonAPICall
 import com.jetsynthesys.rightlife.ui.new_design.pojo.LoggedInUser
 import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
 import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.AppConstants
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import kotlinx.coroutines.launch
@@ -75,7 +76,26 @@ class SyncNowActivity : BaseActivity() {
         val btnSyncNow = findViewById<LinearLayout>(R.id.btn_sync_now)
         val btnSkipForNOw = findViewById<Button>(R.id.btn_skip_for_now)
 
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.SYNC_NOW_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+            )
+        )
+
         btnSyncNow.setOnClickListener {
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.SYNC_NOW_CLICK,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                )
+            )
             val availabilityStatus = HealthConnectClient.getSdkStatus(this)
             if (availabilityStatus == HealthConnectClient.SDK_AVAILABLE) {
                 healthConnectClient = HealthConnectClient.getOrCreate(this)

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/ThirdFillerScreenActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/ThirdFillerScreenActivity.kt
@@ -10,6 +10,9 @@ import android.widget.ImageView
 import android.widget.TextView
 import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.BaseActivity
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.AppConstants
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 
@@ -25,6 +28,16 @@ class ThirdFillerScreenActivity : BaseActivity() {
             header = sharedPreferenceManager.selectedWellnessFocus
         }
         val btnContinue = findViewById<Button>(R.id.btn_continue)
+
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.THREE_TIER_SCREEN_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
 
         var originalText = getString(R.string.third_filler_screen5_thinkright)
 

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/UnlockPowerOfYourMindActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/UnlockPowerOfYourMindActivity.kt
@@ -16,6 +16,9 @@ import com.jetsynthesys.rightlife.ui.new_design.pojo.ModuleTopic
 import com.jetsynthesys.rightlife.ui.new_design.pojo.OnboardingModuleResultDataList
 import com.jetsynthesys.rightlife.ui.new_design.pojo.OnboardingModuleResultRequest
 import com.jetsynthesys.rightlife.ui.new_design.pojo.OnboardingModuleResultResponse
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.Utils
 import retrofit2.Call
@@ -42,6 +45,16 @@ class UnlockPowerOfYourMindActivity : BaseActivity() {
             @Suppress("DEPRECATION")
             selectedWellnessFocus.addAll(intent.getSerializableExtra("SelectedTopic") as ArrayList<ModuleTopic>)
         }
+
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.UNLOCK_POWER_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
 
         val tvHeader = findViewById<TextView>(R.id.tv_header)
         tvUnlockPower = findViewById(R.id.tv_unlock_power)

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/UserInterestActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/UserInterestActivity.kt
@@ -25,6 +25,9 @@ import com.jetsynthesys.rightlife.ui.new_design.pojo.SaveUserInterestResponse
 import com.jetsynthesys.rightlife.ui.new_design.pojo.UserInterestData
 import com.jetsynthesys.rightlife.ui.new_design.pojo.UserInterestResponse
 import com.jetsynthesys.rightlife.ui.profile_new.ProfileSettingsActivity
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.Utils
 import retrofit2.Call
 import retrofit2.Callback
@@ -55,6 +58,16 @@ class UserInterestActivity : BaseActivity() {
         if (header.isNullOrEmpty()) {
             header = sharedPreferenceManager.selectedWellnessFocus
         }
+
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.INTEREST_SELECTION_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
 
         colorStateListSelected = ContextCompat.getColorStateList(this, R.color.menuselected)!!
         colorStateListNonSelected = ContextCompat.getColorStateList(this, R.color.rightlife)!!
@@ -263,6 +276,17 @@ class UserInterestActivity : BaseActivity() {
                         sharedPreferenceManager.interest = true
                         startActivity(intent)
                     }
+                    val selectedInterestString = selectedInterests.joinToString(",") { it.topic.toString() }
+                    AnalyticsLogger.logEvent(
+                        AnalyticsEvent.SAVE_INTEREST,
+                        mapOf(
+                            AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                            AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                            AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                            AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                            AnalyticsParam.SAVED_INTEREST to selectedInterestString
+                        )
+                    )
 
                 } else {
                     Toast.makeText(

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/WeightSelectionFragment.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/WeightSelectionFragment.kt
@@ -20,6 +20,9 @@ import androidx.recyclerview.widget.LinearSnapHelper
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SnapHelper
 import com.jetsynthesys.rightlife.R
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.ConversionUtils
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.disableViewForSeconds
@@ -83,6 +86,17 @@ class WeightSelectionFragment : Fragment() {
         if (!(activity as OnboardingQuestionnaireActivity).forProfileChecklist) {
             (activity as OnboardingQuestionnaireActivity).tvSkip.visibility = VISIBLE
         }
+
+        val sharedPreferenceManager = SharedPreferenceManager.getInstance(requireContext())
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.WEIGHT_SELECTION_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+            )
+        )
 
         kgOption = view.findViewById(R.id.kgOption)
         lbsOption = view.findViewById(R.id.lbsOption)
@@ -177,6 +191,20 @@ class WeightSelectionFragment : Fragment() {
             cardViewSelection.visibility = GONE
             llSelectedWeight.visibility = VISIBLE
             tvSelectedWeight.text = selectedWeight
+
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.WEIGHT_SELECTION,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                    AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule,
+                    AnalyticsParam.GENDER to onboardingQuestionRequest.gender!!,
+                    AnalyticsParam.AGE to onboardingQuestionRequest.age!!,
+                    AnalyticsParam.HEIGHT to onboardingQuestionRequest.height!!,
+                    AnalyticsParam.WEIGHT to selectedWeight
+                )
+            )
 
             /*Handler(Looper.getMainLooper()).postDelayed({
                 OnboardingQuestionnaireActivity.navigateToNextPage()

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/WellnessFocusActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/WellnessFocusActivity.kt
@@ -12,6 +12,9 @@ import com.jetsynthesys.rightlife.R
 import com.jetsynthesys.rightlife.BaseActivity
 import com.jetsynthesys.rightlife.ui.new_design.pojo.ModuleService
 import com.jetsynthesys.rightlife.ui.new_design.pojo.OnBoardingModuleResponse
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.Utils
 import retrofit2.Call
@@ -40,6 +43,15 @@ class WellnessFocusActivity : BaseActivity() {
 
         isFrom = intent.getStringExtra("FROM").toString()
 
+
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.GOAL_SELECTION_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis()
+            )
+        )
+
         setAdapter(-1)
         recyclerView.setLayoutManager(LinearLayoutManager(this))
         recyclerView.adapter = adapter
@@ -54,6 +66,15 @@ class WellnessFocusActivity : BaseActivity() {
             }
             SharedPreferenceManager.getInstance(this).selectedWellnessFocus =
                 selectedService?.moduleName
+
+            AnalyticsLogger.logEvent(
+                AnalyticsEvent.GOAL_SELECTION,
+                mapOf(
+                    AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                    AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                    AnalyticsParam.GOAL to sharedPreferenceManager.selectedWellnessFocus
+                )
+            )
             startActivity(intent)
         }
     }

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/WellnessFocusListActivity.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/new_design/WellnessFocusListActivity.kt
@@ -15,6 +15,9 @@ import com.jetsynthesys.rightlife.ui.new_design.pojo.ModuleTopic
 import com.jetsynthesys.rightlife.ui.new_design.pojo.OnBoardingDataModuleResponse
 import com.jetsynthesys.rightlife.ui.new_design.pojo.OnboardingModuleRequest
 import com.jetsynthesys.rightlife.ui.profile_new.ProfileSettingsActivity
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsEvent
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsLogger
+import com.jetsynthesys.rightlife.ui.utility.AnalyticsParam
 import com.jetsynthesys.rightlife.ui.utility.SharedPreferenceManager
 import com.jetsynthesys.rightlife.ui.utility.Utils
 import okhttp3.ResponseBody
@@ -45,6 +48,14 @@ class WellnessFocusListActivity : BaseActivity() {
         val rvWellnessFocusList = findViewById<RecyclerView>(R.id.rv_wellness_focus_list)
         val btnContinue = findViewById<Button>(R.id.btn_continue)
         val imgHeader = findViewById<ImageView>(R.id.img_header)
+
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.SUB_GOAL_SELECTION_VISIT,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis()
+            )
+        )
 
         // Initialize the TextViews in onCreate
         tv_ur_journey = findViewById(R.id.tv_ur_journey)
@@ -124,6 +135,16 @@ class WellnessFocusListActivity : BaseActivity() {
                 startActivity(intent)
             }
         }
+
+        AnalyticsLogger.logEvent(
+            AnalyticsEvent.SUB_GOAL_SELECTION,
+            mapOf(
+                AnalyticsParam.USER_ID to sharedPreferenceManager.userId,
+                AnalyticsParam.TIMESTAMP to System.currentTimeMillis(),
+                AnalyticsParam.GOAL to sharedPreferenceManager.selectedOnboardingModule,
+                AnalyticsParam.SUB_GOAL to sharedPreferenceManager.selectedOnboardingSubModule
+            )
+        )
     }
 
     private fun getOnboardingDataModule(moduleName: String?) {

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/utility/AnalyticsEvent.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/utility/AnalyticsEvent.kt
@@ -64,6 +64,7 @@ object AnalyticsEvent {
 
     const val FACE_SCAN_PURCHASE_COMPLETED = "face_scan_purchase_completed"
     const val SUBSCRIPTION_PURCHASE_COMPLETED = "subscription_purchase_completed"
+
     // Journal & Affirmation
     const val JOURNAL_ENTRY_CREATED = "journal_entry_created"
     const val JOURNAL_ENTRY_USER = "journal_entry_user"
@@ -81,4 +82,98 @@ object AnalyticsEvent {
 
     const val WEARABLE_SYNC_BUTTON_CLICKED = "wearable_sync_button_clicked"
     const val WEARABLE_SYNC_BUTTON_SKIPED = "wearable_sync_button_skiped"
+
+    const val DATA_CONTROL_SCREEN_VISIT = "data_control_screen_visit"
+    const val LOGIN_SCREEN_VISIT = "login_screen_visit"
+    const val CONTINUE_WITH_GOOGLE_CLICK = "continue_with_google_click"
+    const val CREATE_USER_SCREEN_VISIT = "create_user_screen_visit"
+
+    const val GOAL_SELECTION_VISIT = "goal_selection_visit"
+    const val GOAL_SELECTION = "goal_selection"
+    const val SUB_GOAL_SELECTION_VISIT = "sub_goal_selection_visit"
+    const val SUB_GOAL_SELECTION = "sub_goal_selection"
+
+    const val UNLOCK_POWER_VISIT = "unlock_power_visit"
+    const val THREE_TIER_SCREEN_VISIT = "three_tier_screen_visit"
+    const val INTEREST_SELECTION_VISIT = "interest_selection_visit"
+    const val SAVE_INTEREST = "save_interest"
+
+    const val ALLOW_PERSONALISATION_VISIT = "allow_personalisation_visit"
+    const val ALLOW_PERSONALISATION_CLICK = "allow_personalisation_click"
+    const val ALLOW_PERSONALISATION_SKIP_CLICK = "allow_personalisation_skip_click"
+
+    const val GENDER_SELECTION_VISIT = "gender_selection_visit"
+    const val GENDER_SELECTION = "gender_selection"
+    const val GENDER_SELECTION_SKIP_CLICK = "gender_selection_skip_click"
+
+    const val AGE_SELECTION_VISIT = "age_selection_visit"
+    const val AGE_SELECTION = "age_selection"
+    const val AGE_SELECTION_SKIP = "age_selection_skip"
+
+    const val HEIGHT_SELECTION_VISIT = "height_selection_visit"
+    const val HEIGHT_SELECTION = "height_selection"
+    const val HEIGHT_SELECTION_SKIP = "height_selection_skip"
+
+    const val WEIGHT_SELECTION_VISIT = "weight_selection_visit"
+    const val WEIGHT_SELECTION = "weight_selection"
+    const val WEIGHT_SELECTION_SKIP = "weight_selection_skip"
+
+    const val BODY_FAT_SELECTION_VISIT = "body_fat_selection_visit"
+    const val BODY_FAT_SELECTION = "body_fat_selection"
+    const val BODY_FAT_SELECTION_SKIP = "body_fat_selection_skip"
+
+    const val STRESS_MANAGEMENT_VISIT = "stress_management_visit"
+    const val STRESS_MANAGEMENT_SELECTION = "stress_management_selection"
+    const val STRESS_MANAGEMENT_SKIP = "stress_management_skip"
+
+    const val ACHIEVE_HEALTH_GOALS_VISIT = "acheive_health_goals_visit"
+    const val ACHIEVE_HEALTH_GOALS_SELECTION = "acheive_health_goals_selection"
+    const val ACHIEVE_HEALTH_GOALS_SKIP = "acheive_health_goals_skip"
+
+    const val ENABLE_NOTIFICATION_CLOSE = "enable_nofication_close"
+    const val ENABLE_NOTIFICATION_CLICK = "enable_nofication_click"
+
+    const val SYNC_NOW_VISIT = "sync_now_visit"
+    const val SYNC_NOW_CLICK = "sync_now_click"
+    const val SKIP_FOR_NOW_CLICK = "skip_for_now_click"
+
+    const val BEGIN_FREE_TRIAL_VISIT = "begin_free_trial_visit"
+    const val BEGIN_FREE_TRIAL_CLICK = "begin_free_trial_click"
+    const val CRAFTING_PERSONALISE_VISIT = "crafting_personalise_visit"
+    const val AWESOME_SCREEN_VISIT = "awesome_screen_visit"
+
+    const val HOME_DASHBOARD_VISIT = "home_dashboard_visit"
+
+    const val CHECKLIST_STATUS = "checklist_status"
+    const val PROFILE_STATUS = "profile_status"
+    const val SNAP_MEAL_STATUS = "snap_meal_status"
+    const val ER_MR_ASSESSMENT_STATUS = "ER_MR_assessment_status"
+    const val TR_SR_ASSESSMENT_STATUS = "TR_SR_assessment_status"
+    const val SYNC_DATA_STATUS = "sync_data_status"
+    const val FACIAL_SCAN_STATUS = "facial_scan_status"
+
+    const val WHY_CHECKLIST_CLICK = "why_checklist_click"
+    const val FINISH_TO_UNLOCK_CLICK = "finish_to_unlock_click"
+    const val SUBSCRIBE_RIGHT_LIFE_CLICK = "subscribe_rightlife_click"
+
+    const val LYA_FOOD_LOG_CLICK = "lya_food_log_click"
+    const val LYA_ACTIVITY_LOG_CLICK = "lya_activity_log_click"
+    const val LYA_SLEEP_LOG_CLICK = "lya_sleep_log_click"
+    const val LYA_WEIGHT_LOG_CLICK = "lya_weight_log_click"
+    const val LYA_WATER_LOG_CLICK = "lya_water_log_click"
+
+    const val EOS_FACE_SCAN_CLICK = "eos_face_scan_click"
+    const val EOS_SNAP_MEAL_CLICK = "eos_snap_meal_click"
+    const val EOS_SLEEP_SOUNDS = "eos_sleep_sounds"
+    const val EOS_AFFIRMATION_CLICK = "eos_affirmation_click"
+    const val EOS_JOURNALING_CLICK = "eos_journaling_click"
+    const val EOS_BREATH_WORK_CLICK = "eos_breathwork_click"
+
+    const val MOVE_RIGHT_CLICK = "move_right_click"
+    const val EAT_RIGHT_CLICK = "eat_right_click"
+    const val SLEEP_RIGHT_CLICK = "sleep_right_click"
+    const val THINK_RIGHT_CLICK = "think_right_click"
+
+    const val ALL_HEALTH_DATA_CLICK = "all_health_data_click"
+    const val DISCOVER_CLICK = "discover_click"
 }

--- a/app/src/main/java/com/jetsynthesys/rightlife/ui/utility/AnalyticsParam.kt
+++ b/app/src/main/java/com/jetsynthesys/rightlife/ui/utility/AnalyticsParam.kt
@@ -8,6 +8,8 @@ object AnalyticsParam {
     const val WEIGHT = "weight"
     const val HEIGHT = "height"
     const val GOAL = "goal"
+    const val BODY_FAT = "body_fat"
+    const val STRESS_MANAGEMENT = "stress_management"
     const val SUB_GOAL = "subgoal"
     const val USER_PLAN = "user_plan"
     const val TIMESTAMP = "timestamp"
@@ -38,4 +40,8 @@ object AnalyticsParam {
     const val DATA_EXPORT_REQUESTED = "data_export_requested"
     const val ACCOUNT_DELETED = "account_deleted"
     const val USER_SIGN_OUT = "user_signout"
+    const val SAVED_INTEREST = "selected_interest"
+    const val PROFILE_STATUS = "profile_status"
+    const val HEALTH_DATA_TYPE = "health_data_type"
+    const val DISCOVER_TYPE = "discover_type"
 }

--- a/app/src/main/res/layout/fragment_home_dashboard.xml
+++ b/app/src/main/res/layout/fragment_home_dashboard.xml
@@ -49,7 +49,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="5dp"
             android:layout_weight="1"
-            android:visibility="visible"
+            android:visibility="gone"
             app:cardCornerRadius="@dimen/margin_card_16dp">
 
             <LinearLayout
@@ -2178,7 +2178,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="5dp"
                 android:layout_weight="1"
-                android:visibility="visible"
+                android:visibility="gone"
                 app:cardCornerRadius="@dimen/margin_card_16dp">
 
                 <RelativeLayout
@@ -2264,6 +2264,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="5dp"
                 android:layout_weight="1"
+                android:visibility="gone"
                 app:cardCornerRadius="@dimen/margin_card_16dp">
 
                 <RelativeLayout
@@ -2359,7 +2360,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="5dp"
                 android:layout_weight="1"
-                android:visibility="visible"
+                android:visibility="gone"
                 app:cardCornerRadius="@dimen/margin_card_16dp">
 
                 <RelativeLayout
@@ -2432,7 +2433,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="5dp"
                 android:layout_weight="1"
-                android:visibility="visible"
+                android:visibility="gone"
                 app:cardCornerRadius="@dimen/margin_card_16dp">
 
                 <RelativeLayout
@@ -2537,7 +2538,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_centerVertical="true"
-                android:background="@drawable/rounded_corder_border_gray_radius_small"
+                android:background="@drawable/bg_gray_border_radius_small"
                 android:orientation="vertical">
 
                 <TextView


### PR DESCRIPTION
- Data Control Screen
- Login Screen
- CreateUserName
- Wellness Focus selection
- Sub Goal Selection
- Unlock the Power
- 3 tier screen
- Interest Selection
- Allow Personalization
- Onboarding Screen
- Enable Notification
- Sync Now
- Begin My Free Trial
- Crafting Personalise Experience Screen
- Awesome Screen
- Home Dashboard
- RAD-3152: QA>Home>Dashboard screen issues
- RAD-3625: View Past Reports_Profile Page_Android